### PR TITLE
Added simple manifest file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Reorder the asset `preconnect` and remove unneeded `dns-prefetch` ([Issue 9](https://github.com/nhsx/nhsx-website/issues/9))
 - Terms and conditions content amendments
 - Update the default `BASE_URL` to include www.
+- Added simple Web App Manifest file
 
 ## 1.0.0 - 04/04/2019
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -72,6 +72,11 @@ router.get('/sitemap', (req, res) => {
   res.render('pages/sitemap');
 });
 
+router.get('/manifest.json', (req, res) => {
+  res.set({ 'Content-Type': 'application/json' });
+  res.render('manifest');
+});
+
 router.use((req, res) => {
   res.statusCode = 404;
   res.render('pages/404');

--- a/app/views/includes/layout.njk
+++ b/app/views/includes/layout.njk
@@ -22,6 +22,8 @@
     <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2" rel="preload" as="font" crossorigin>
     <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff2" rel="preload" as="font" crossorigin>
 
+    <link rel="manifest" href="/manifest.json">
+
     <!--[if IE]><link rel="shortcut icon" href="/nhsuk-frontend/assets/favicons/favicon.ico"><![endif]-->
     <link rel="apple-touch-icon" href="/nhsuk-frontend/assets/favicons/apple-touch-icon.png">
     <link rel="icon" href="/nhsuk-frontend/assets/favicons/favicon.png">

--- a/app/views/manifest.njk
+++ b/app/views/manifest.njk
@@ -1,0 +1,18 @@
+{
+  "lang": "en",
+  "name": "NHSX Website",
+  "short_name": "NHSX",
+  "description": "{% if pageDescription %}{{pageDescription}}{% else %}NHSX - a new unit driving forward the digital transformation of health and care.{% endif %}",
+  "theme_color": "#003087",
+  "background_color": "#003087",
+  "start_url": "/",
+  "display": "browser",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/nhsuk-frontend/assets/favicons/favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
Added a very simple `manifest.json` file that is used by the [Web App Manifest](https://developers.google.com/web/fundamentals/web-app-manifest/). Initially included as a nunjucks template to include a custom description, or if you would like any of the members to come from a central config. Could simply be a static JSON file sitting in an assets folder then routed to the root directory using express if preferred. 

`"display": "browser"` is used as it is default. I don't want to assume what browser UI a user would expect when added to homescreen (it doesn't currently [meet the criteria](https://developers.google.com/web/fundamentals/app-install-banners/#criteria) for the automatic A2HS prompt). 