### PR TITLE
selectively import NHS.UK frontend component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Amend heading structure on various pages so there is no jumping from a H1 to a H3
 - Add title attribute to iframe video on the homepage
+- Selectively import NHS.UK frontend component scss files to reduce the compiled CSS file size
 
 ## 1.0.2 - 15/04/2019
 

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,5 +1,18 @@
 // NHS.UK frontend
-@import 'node_modules/nhsuk-frontend/packages/nhsuk';
+@import 'node_modules/nhsuk-frontend/packages/core/all';
+
+@import 'node_modules/nhsuk-frontend/packages/components/breadcrumb/breadcrumb';
+@import 'node_modules/nhsuk-frontend/packages/components/button/button';
+@import 'node_modules/nhsuk-frontend/packages/components/fieldset/fieldset';
+@import 'node_modules/nhsuk-frontend/packages/components/footer/footer';
+@import 'node_modules/nhsuk-frontend/packages/components/header/header';
+@import 'node_modules/nhsuk-frontend/packages/components/hero/hero';
+@import 'node_modules/nhsuk-frontend/packages/components/input/input';
+@import 'node_modules/nhsuk-frontend/packages/components/label/label';
+@import 'node_modules/nhsuk-frontend/packages/components/panel/panel';
+@import 'node_modules/nhsuk-frontend/packages/components/promo/promo';
+@import 'node_modules/nhsuk-frontend/packages/components/radios/radios';
+@import 'node_modules/nhsuk-frontend/packages/components/skip-link/skip-link';
 
 // NHSX website styles
 @import 'nhsx';


### PR DESCRIPTION
## Description

We only use 14 of the 34 components from the NHS.UK frontend library, so we can selectively import the components that we use on the NHSX website to reduce the compiled CSS file size on the website. Which results in smaller builds, smaller CSS files and potentially faster loading.

CSS file size reduction:  **105kb** to **73kb** (without server optimisation/gzip)

### Related issue
N/A

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Documentation
- [x] Version number increase (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] Validated on staging environment (only required for releases)
