### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# NHSX code of conduct
+
+## Our pledge
+
+In order to create an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of:
+
+* age
+* body size
+* disability
+* ethnicity
+* gender identity and expression
+* level of experience
+* nationality
+* personal appearance
+* race
+* religion
+* sexual identity and orientation
+
+## Our standards
+
+You can contribute to creating a positive environment in many ways. For example you can:
+
+* use welcoming and inclusive language
+* be respectful of differing viewpoints and experiences
+* accept constructive criticism gracefully
+* focus on what is best for the community
+* show empathy towards other community members
+
+You should not:
+
+* use sexualised language or imagery
+* make unwelcome sexual advances
+* troll, and make insulting or derogatory comments
+* make personal or political attacks
+* harass others, in public or private
+* publish others' private information, such as a physical or electronic address, without explicit permission
+* engage in any other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our responsibilities
+
+As project maintainers, we are responsible for clarifying the standards of acceptable behaviour and we are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.
+
+We have the right and responsibility to remove, edit, or reject:
+
+* comments
+* commits
+* code
+* wiki edits
+* issues
+* other contributions that are not aligned to this code of conduct
+
+We also reserve the right to temporarily or permanently ban any contributor for other behaviours we deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This code of conduct applies whenever you are representing the project or community. For example you may be:
+
+* working in a project space online or in the public
+* using an official project email address
+* posting via an official social media account
+* participating in an online or offline event
+
+Project maintainers may further define and clarify representation of a project.
+
+## Enforcement
+
+You should report any instances of abusive, harassing, or otherwise unacceptable behaviour to the project team at opensource@nhsx.nhs.uk. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain the anonymity of the reporter of an incident. We may post further details of specific enforcement policies separately.
+
+Project maintainers who do not follow or enforce this code of conduct in good faith may face temporary or permanent consequences. These will be determined by members of the project's leadership.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant][http://contributor-covenant.org], version 1.4, available at [http://contributor-covenant.org/version/1/4][http://contributor-covenant.org/version/1/4/]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,4 +70,4 @@ Project maintainers who do not follow or enforce this code of conduct in good fa
 
 ## Attribution
 
-This code of conduct is adapted from the [Contributor Covenant][http://contributor-covenant.org], version 1.4, available at [http://contributor-covenant.org/version/1/4][http://contributor-covenant.org/version/1/4/]
+This code of conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/)


### PR DESCRIPTION
Fixes #13

Waiting for email address to go live before publishing.

## Description
Adds a CoC to the repo.

### Related issue
#13 

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [ ] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [ ] Documentation
- [ ] Version number increase (using [SEMVER](https://semver.org/))
- [ ] CHANGELOG entry
- [ ] Validated on staging environment (only required for releases)
