### PR TITLE
added cookie updates in line with nhsuk script update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.0 - 14/06/2019
+
+- Changed cookie policy page rules to only accept cookies when settings are changed and saved
+- Changed cookie policy page to keep same url when settings save and confirmation banner shows
+
 ## 1.1.2 - 12/06/2019
 
 - Import all the NHS.UK frontend library components for future development

--- a/app/views/pages/our-policies/cookies-policy.njk
+++ b/app/views/pages/our-policies/cookies-policy.njk
@@ -99,19 +99,19 @@
         function changeConsent() {
           NHSCookieConsent.setPreferences(document.getElementById("input-preferences-1").checked);
           NHSCookieConsent.setStatistics(document.getElementById("input-statistics-1").checked);
+          if(typeof NHSCookieConsent.setConsented === "function") {
+            NHSCookieConsent.setConsented(true);
         }
 
         function reloadPage() {
-          if(document.location.search === "?cookie-changed=1") {
-            document.location.reload();
-          } else {
-            document.location.search = "?cookie-changed=1";
-          }
+          NHSCookieConsent.setConfirmation(true);
+          document.location.reload();
+          window.scrollTo(0, 0);
         }
 
         function loadSuccessBanner() {
           var url = window.location.href;
-          if (url.indexOf('cookie-changed=1') > 0) {
+          if (NHSCookieConsent.getConfirmation() === true) {
             var html = "<div id='nhsuk-cookie-confirmation-banner' role='banner'>" +
               "<div class='nhsuk-width-container'>" +
               "<p>Your cookie settings have been saved.</p>" +
@@ -131,6 +131,7 @@
             var div = document.createElement('div');
             div.innerHTML = html;
             document.body.insertBefore(div, document.body.firstChild);
+            NHSCookieConsent.setConfirmation(false);
           }
         }
       </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsx-website",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "The NHSX website",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Description
This change is needed to be in line with the new cookie consent changes on nhs.uk. It supports the new consent rules (A user only consents by changing and saving their settings now). 

See - https://github.com/nhsuk/cookie-consent/commit/d21d0daec661ec04586e356e4c1736e7af588d94 for the corresponding change

### Related issue
<!--- If there is an open GitHub issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Documentation
- [x] Version number increase (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [ ] Validated on staging environment (only required for releases)
