### PR TITLE
use correct value for the manifest display property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.2 - 01/07/2019
 
 - Content updates across the website for the 1st July launch
+- Use correct value for the manifest display property
 - Update to NHS.UK frontend v2.2.0 and use the new favicons
 - Update package dependencies to latest versions
 

--- a/app/views/manifest.njk
+++ b/app/views/manifest.njk
@@ -6,7 +6,7 @@
   "theme_color": "#003087",
   "background_color": "#003087",
   "start_url": "/",
-  "display": "browser",
+  "display": "standalone",
   "orientation": "portrait",
   "icons": [
     {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`"display": "browser"` was causing Google chrome to give console errors.

<img width="601" alt="Screenshot 2019-07-01 at 09 46 46" src="https://user-images.githubusercontent.com/11615501/60423036-2c9fd880-9be5-11e9-91f5-dc371e0386da.png">

### Related issue
<!--- If there is an open GitHub issue, please link to the issue here -->

## Checklist
<!-- Ensure each of the points below have been considered and completed where applicable -->

- [x] Tested against the [NHS.UK frontend testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] Code follows the [NHS.UK frontend coding standards](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/coding-standards.md)
- [x] Documentation
- [x] Version number increase (using [SEMVER](https://semver.org/))
- [x] CHANGELOG entry
- [x] Validated on staging environment (only required for releases)
